### PR TITLE
Add lifecycle state subscriber and GUI update hook

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
@@ -106,6 +106,9 @@ class AUVControlGUI(QWidget):
         # === BUILD THE GUI ===
         self.init_ui()
 
+        # Allow ROS node to trigger UI updates when lifecycle state changes
+        self.ros_node.lifecycle_update_callback = self.update_lifecycle_buttons
+
 
 
         # === NOW SAFELY START THE TIMER ===


### PR DESCRIPTION
## Summary
- track lifecycle state via `servo_driver/lifecycle_state`
- notify GUI when lifecycle state messages arrive
- fallback lifecycle polling slowed to 10s

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: ament_*)*

------
https://chatgpt.com/codex/tasks/task_e_684979f36ce4833297e38cabc0280ce9