### PR TITLE
Enhance IMU health handling

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
@@ -571,18 +571,20 @@ class AUVControlGUI(QWidget):
         
         # === Update IMU Health Label ===
         imu_health = self.ros_node.imu_health_status
+        normalized = imu_health.upper()
 
-        if imu_health == "IMU OK":
+        if normalized == "IMU OK":
             self.imu_health_label.setText("IMU HEALTH: OK")
             self.imu_health_label.setStyleSheet("font-size: 18px; color: #00FF00;")
-        elif "UNSTABLE" in imu_health:
+        elif "UNSTABLE" in normalized:
             self.imu_health_label.setText(f"IMU HEALTH: {imu_health}")
             self.imu_health_label.setStyleSheet("font-size: 18px; color: #FFA500;")  # Orange
-        elif "RESTARTING" in imu_health:
+        elif "RESTARTING" in normalized:
             self.imu_health_label.setText(f"IMU HEALTH: {imu_health}")
             self.imu_health_label.setStyleSheet("font-size: 18px; color: #FF4500;")  # Red
         else:
-            self.imu_health_label.setText("IMU HEALTH: UNKNOWN")
+            # Display unrecognised status text directly
+            self.imu_health_label.setText(f"IMU HEALTH: {imu_health or 'UNKNOWN'}")
             self.imu_health_label.setStyleSheet("font-size: 18px; color: #AAAAAA;")
             
         servo_status = self.ros_node.servo_driver_status

--- a/src/remote_pi_pkg/remote_pi_pkg/ros/interface.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/ros/interface.py
@@ -151,10 +151,14 @@ class ROSInterface(Node):
 
         
     def imu_health_callback(self, msg):
-        
-        self.imu_health_status = msg.data
-        self.get_logger().info(f"[ROSInterface] IMU Health Status: {self.imu_health_status}")
-        self.get_logger().debug(f"IMU HEALTH CALLBACK FIRED: {msg.data}")
+        """Store IMU health status from the '/imu/health_status' topic."""
+
+        # Normalize whitespace for consistent GUI display
+        self.imu_health_status = msg.data.strip()
+        self.get_logger().info(
+            f"[ROSInterface] IMU Health Status: {self.imu_health_status}")
+        self.get_logger().debug(
+            f"IMU HEALTH CALLBACK FIRED: {self.imu_health_status}")
         
 
 


### PR DESCRIPTION
## Summary
- strip whitespace in IMU health callback
- support arbitrary IMU health strings in the GUI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: ament_copyright, ament_flake8, ament_pep257)*

------
https://chatgpt.com/codex/tasks/task_e_68497d6bb39c8332ae227b8d4fbf7f7b