### PR TITLE
Add canned movement helper and dynamic buttons

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/__init__.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/__init__.py
@@ -1,0 +1,1 @@
+from .canned_movements import CannedMovements

--- a/src/remote_pi_pkg/remote_pi_pkg/canned_movements.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/canned_movements.py
@@ -1,0 +1,37 @@
+class CannedMovements:
+    """Helper exposing one method per canned movement step."""
+
+    def __init__(self, ros_interface):
+        self._ros = ros_interface
+
+    def _send(self, index, duration=None):
+        if duration is None:
+            duration = self._ros.canned_default_durations[index]
+        self._ros.publish_canned_step(index, duration)
+
+    def canned_pitch_up(self, duration=None):
+        self._send(0, duration)
+
+    def canned_swing_up(self, duration=None):
+        self._send(1, duration)
+
+    def canned_up_glide(self, duration=None):
+        self._send(2, duration)
+
+    def canned_pitch_down(self, duration=None):
+        self._send(3, duration)
+
+    def canned_swing_down(self, duration=None):
+        self._send(4, duration)
+
+    def canned_down_glide(self, duration=None):
+        self._send(5, duration)
+
+    def canned_pitch_up_2(self, duration=None):
+        self._send(6, duration)
+
+    def canned_wing_to_glide(self, duration=None):
+        self._send(7, duration)
+
+    def canned_glide(self, duration=None):
+        self._send(8, duration)

--- a/src/remote_pi_pkg/remote_pi_pkg/ros/interface.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/ros/interface.py
@@ -7,7 +7,8 @@ from lifecycle_msgs.srv import ChangeState
 from lifecycle_msgs.msg import Transition
 from geometry_msgs.msg import Vector3  
 from std_msgs.msg import String   
-from lifecycle_msgs.srv import GetState     
+from lifecycle_msgs.srv import GetState
+from remote_pi_pkg import CannedMovements
 
 
 
@@ -40,6 +41,9 @@ class ROSInterface(Node):
         ]
         self.canned_easing_in = [0.0] * 9
         self.canned_easing_out = [0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1]
+
+        # Helper for sending individual canned steps
+        self.canned_movements = CannedMovements(self)
 
         # Sensor readouts
         self.current_servo_angles = []  # List of 6 servo angles


### PR DESCRIPTION
## Summary
- add new `CannedMovements` helper for publishing individual canned steps
- expose helper via package `__init__`
- instantiate helper from `ROSInterface`
- build manual step buttons dynamically in the GUI
- remove now unused `send_canned_step` method

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ament_flake8')*

------
https://chatgpt.com/codex/tasks/task_e_685130ea6aec8332a33718d661cc47d0