### PR TITLE
Add navigation tab with joystick

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/ros/interface.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/ros/interface.py
@@ -116,6 +116,8 @@ class ROSInterface(Node):
 
         if hasattr(self, 'attitude_widget'):
             self.attitude_widget.set_acceleration(msg.x, msg.y, msg.z)
+        if hasattr(self, 'nav_attitude_widget'):
+            self.nav_attitude_widget.set_acceleration(msg.x, msg.y, msg.z)
 
 
         
@@ -123,8 +125,10 @@ class ROSInterface(Node):
         self.depth = msg.data  # Existing storage
 
         # Push the update to the GUI widget:
-        if hasattr(self, 'attitude_widget'):  # Check if widget exists
+        if hasattr(self, 'attitude_widget'):
             self.attitude_widget.set_depth(msg.data)
+        if hasattr(self, 'nav_attitude_widget'):
+            self.nav_attitude_widget.set_depth(msg.data)
 
 
         


### PR DESCRIPTION
## Summary
- add a NAVIGATION tab to the GUI
- show heading HUD, attitude indicator, canned movement buttons and joystick
- update widgets in `update_visuals` and `update_status`
- provide incremental joystick control for navigation
- forward depth and acceleration data to the new widget

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ament_copyright')*

------
https://chatgpt.com/codex/tasks/task_e_685516fc247483328c8c45192cdaaf0a