### PR TITLE
Adjust canned movement button heights

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
@@ -279,7 +279,7 @@ class AUVControlGUI(QWidget):
             else:
                 label = match.group(1)
             btn = QPushButton(label)
-            btn.setFixedHeight(50)
+            btn.setFixedHeight(35)
             btn.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
             method = getattr(self.ros_node.canned_movements, name)
             btn.clicked.connect(
@@ -315,7 +315,7 @@ class AUVControlGUI(QWidget):
             else:
                 label = match.group(1)
             btn = QPushButton(label)
-            btn.setFixedHeight(50)
+            btn.setFixedHeight(35)
             btn.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
             method = getattr(self.ros_node.canned_movements, name)
             btn.clicked.connect(


### PR DESCRIPTION
## Summary
- shrink manual and navigation canned movement button heights from 50px to 35px

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68551d472cec833289fd2cb055e3e0c5