### PR TITLE
Fix roll arc sizing

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/widgets/attitude_indicator.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/widgets/attitude_indicator.py
@@ -235,8 +235,9 @@ class AttitudeIndicator(QWidget):
         painter.drawLine(width - marker_length, center_y, width - marker_margin, center_y)
 
         # === Roll Arc & Marker ===
-        arc_radius = width * 0.27
-        arc_center = QPointF(width - arc_radius - 20, center_y)
+        # Use a fixed geometry so the arc remains visible across widget sizes
+        arc_radius = 140
+        arc_center = QPointF(260, center_y)
         arc_rect = QRectF(arc_center.x() - arc_radius,
                         arc_center.y() - arc_radius,
                         arc_radius * 2,


### PR DESCRIPTION
## Summary
- fix the roll indicator arc so it uses a fixed geometry

## Testing
- `colcon test --packages-select remote_pi_pkg` *(fails: `colcon` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567382f77c8332b212049bb9f24425