### PR TITLE
Allow dynamic cruise interval updates

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
@@ -708,6 +708,8 @@ class AUVControlGUI(QWidget):
     def update_cruise_interval_label(self):
         self.cruise_interval_label.setText(f"{self.cruise_interval_spin.value():.1f}s")
         self.ros_node.cruise_delay = self.cruise_interval_spin.value()
+        if self.ros_node.cruise_enabled:
+            self.ros_node.restart_cruise_timer()
 
     def joystick_callback(self, norm_x, norm_y):
         max_angle = 15.0  # or change to 45.0 for tighter control

--- a/src/remote_pi_pkg/remote_pi_pkg/ros/interface.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/ros/interface.py
@@ -117,6 +117,18 @@ class ROSInterface(Node):
         self.cruise_timer = None
         self.last_servo_status_word = None
         self.auto_pid_reengage = True
+
+    def restart_cruise_timer(self):
+        """Restart the cruise timer using the current delay."""
+        if self.cruise_timer:
+            self.cruise_timer.cancel()
+            self.cruise_timer = None
+
+        if self.cruise_enabled and self.last_canned_callback and \
+                self.last_servo_status_word == "nominal":
+            self.cruise_timer = threading.Timer(
+                self.cruise_delay, self.execute_cruise)
+            self.cruise_timer.start()
         
     def acceleration_callback(self, msg: Vector3):
         #print(f"[ROSInterface] Received accel: x={msg.x}, y={msg.y}, z={msg.z}")


### PR DESCRIPTION
## Summary
- add `restart_cruise_timer` helper in ROS interface
- restart cruise timer when interval value changes

## Testing
- `python -m py_compile src/remote_pi_pkg/remote_pi_pkg/ros/interface.py src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ament_copyright')*

------
https://chatgpt.com/codex/tasks/task_e_6857b2107e5483328dbebdb426051023