### PR TITLE
Add button action map for gamepad node

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/ros/gamepad_mapper.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/ros/gamepad_mapper.py
@@ -36,6 +36,28 @@ class GamepadMapper(Node):
 
         self.canned_movements = CannedMovements(self)
 
+        # Map joystick button indices to handler methods. Indices refer to the
+        # order provided by the Joy message from the controller.
+        self.button_actions = {
+            0: self.canned_movements.canned_1_low_thrust,       # A button
+            1: self.canned_movements.canned_2_medium_thrust,    # B button
+            2: self.canned_movements.canned_3_high_thrust,      # X button
+            3: self.canned_movements.canned_4_forward_right,    # Y button
+            4: self.canned_movements.canned_5_forward_left,     # Left bumper
+            5: self.canned_movements.canned_6_hard_right,       # Right bumper
+            6: self.canned_movements.canned_7_hard_left,        # Back
+            7: self.canned_movements.canned_8_tail_thrust,      # Start
+            8: self.canned_movements.canned_9_SWING_UP,         # Stick press L
+            9: self.canned_movements.canned_10_DOWN_TO_GLIDE,   # Stick press R
+            10: self.canned_movements.canned_11_UP_TO_GLIDE,    # D-pad up
+            11: self.canned_movements.canned_12_SWING_DOWN,     # D-pad down
+            12: self.canned_movements.canned_13_ACCEL,          # D-pad left
+            13: self.toggle_cruise,                             # D-pad right
+            14: self.increase_duration_factor,                  # Misc button 1
+            15: self.decrease_cruise_delay,                     # Misc button 2
+            16: self.increase_cruise_delay,                     # Misc button 3
+        }
+
     def joy_callback(self, msg: Joy):
         # axes[2] -> roll, axes[3] -> pitch
         if len(msg.axes) > 3:
@@ -48,41 +70,15 @@ class GamepadMapper(Node):
             self.last_buttons = [0] * len(msg.buttons)
 
         def pressed(index: int) -> bool:
-            return len(msg.buttons) > index and msg.buttons[index] and not self.last_buttons[index]
+            return (
+                len(msg.buttons) > index
+                and msg.buttons[index]
+                and not self.last_buttons[index]
+            )
 
-        canned_methods = [
-            self.canned_movements.canned_1_low_thrust,
-            self.canned_movements.canned_2_medium_thrust,
-            self.canned_movements.canned_3_high_thrust,
-            self.canned_movements.canned_4_forward_right,
-            self.canned_movements.canned_5_forward_left,
-            self.canned_movements.canned_6_hard_right,
-            self.canned_movements.canned_7_hard_left,
-            self.canned_movements.canned_8_tail_thrust,
-            self.canned_movements.canned_9_SWING_UP,
-            self.canned_movements.canned_10_DOWN_TO_GLIDE,
-            self.canned_movements.canned_11_UP_TO_GLIDE,
-            self.canned_movements.canned_12_SWING_DOWN,
-            self.canned_movements.canned_13_ACCEL,
-        ]
-
-        for idx, method in enumerate(canned_methods):
+        for idx, action in self.button_actions.items():
             if pressed(idx):
-                method()
-
-        control_idx = len(canned_methods)
-        if pressed(control_idx):
-            self.cruise_enabled = not self.cruise_enabled
-            self.cruise_enabled_pub.publish(Bool(data=self.cruise_enabled))
-        if pressed(control_idx + 1):
-            self.canned_duration_factor += 0.2
-            self.duration_factor_pub.publish(Float32(data=self.canned_duration_factor))
-        if pressed(control_idx + 2):
-            self.cruise_delay = max(0.5, self.cruise_delay - 0.5)
-            self.cruise_delay_pub.publish(Float32(data=self.cruise_delay))
-        if pressed(control_idx + 3):
-            self.cruise_delay += 0.5
-            self.cruise_delay_pub.publish(Float32(data=self.cruise_delay))
+                action()
 
         self.last_buttons = list(msg.buttons)
 
@@ -106,6 +102,28 @@ class GamepadMapper(Node):
 
     def set_tail_pid(self, activate: bool):
         self.tail_pid_pub.publish(Bool(data=activate))
+
+    def toggle_cruise(self):
+        """Toggle cruise mode on/off and publish state."""
+        self.cruise_enabled = not self.cruise_enabled
+        self.cruise_enabled_pub.publish(Bool(data=self.cruise_enabled))
+
+    def increase_duration_factor(self):
+        """Increase canned movement duration scaling."""
+        self.canned_duration_factor += 0.2
+        self.duration_factor_pub.publish(
+            Float32(data=self.canned_duration_factor)
+        )
+
+    def decrease_cruise_delay(self):
+        """Reduce delay between cruise cycles."""
+        self.cruise_delay = max(0.5, self.cruise_delay - 0.5)
+        self.cruise_delay_pub.publish(Float32(data=self.cruise_delay))
+
+    def increase_cruise_delay(self):
+        """Increase delay between cruise cycles."""
+        self.cruise_delay += 0.5
+        self.cruise_delay_pub.publish(Float32(data=self.cruise_delay))
 
 
 def main(args=None):


### PR DESCRIPTION
## Summary
- refactor `gamepad_mapper` to use a dictionary of button actions
- expose helper methods for cruise and timing controls
- update `joy_callback` to iterate over this mapping
- document button indices with inline comments

## Testing
- `colcon test --packages-select remote_pi_pkg` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685933d8ff808332beaec804c064ffec