### PR TITLE
Improve gamepad sync with GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ RemotePiRos2/
    ./launch_gui.sh
    ```
 
-The script sources `/opt/ros/jazzy/setup.bash` and the workspace's `install/setup.bash`, then runs `ros2 run remote_pi_pkg auv_control`. The `auv_control` entry point automatically starts `joy_linux` and the internal gamepad mapper so joystick input is available without additional commands.
+The script sources `/opt/ros/jazzy/setup.bash` and the workspace's `install/setup.bash`, then runs `ros2 run remote_pi_pkg auv_control`. The `auv_control` entry point automatically starts the standard `joy` node and the internal gamepad mapper so joystick input is available without additional commands.
 
 ## ROS 2 overview
 

--- a/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
@@ -120,6 +120,9 @@ class AUVControlGUI(QWidget):
 
         # Allow ROS node to trigger UI updates when lifecycle state changes
         self.ros_node.lifecycle_update_callback = self.update_lifecycle_buttons
+        self.ros_node.cruise_enabled_update_callback = self.on_cruise_enabled_update
+        self.ros_node.cruise_delay_update_callback = self.on_cruise_delay_update
+        self.ros_node.step_duration_update_callback = self.on_step_duration_update
 
 
 
@@ -642,6 +645,34 @@ class AUVControlGUI(QWidget):
         else:
             self.btn_cruise_toggle.setText("CRUISE: OFF")
             self.btn_cruise_toggle.setStyleSheet("border: 2px solid #FF4500; color: #FF4500;")
+
+    def on_cruise_enabled_update(self, enabled: bool):
+        """Update cruise toggle when state changes via ROS."""
+        self.btn_cruise_toggle.setChecked(enabled)
+        if enabled:
+            self.btn_cruise_toggle.setText("CRUISE: ON")
+            self.btn_cruise_toggle.setStyleSheet("border: 2px solid #00FF00; color: #00FF00;")
+        else:
+            self.btn_cruise_toggle.setText("CRUISE: OFF")
+            self.btn_cruise_toggle.setStyleSheet("border: 2px solid #FF4500; color: #FF4500;")
+
+    def on_cruise_delay_update(self, delay: float):
+        """Update cruise interval spin box from ROS."""
+        self.cruise_interval_spin.blockSignals(True)
+        self.cruise_interval_spin.setValue(delay)
+        self.cruise_interval_spin.blockSignals(False)
+        self.update_cruise_interval_label()
+
+    def on_step_duration_update(self, duration: float):
+        """Sync step duration spin boxes when changed externally."""
+        self.manual_duration_spin.blockSignals(True)
+        self.navigation_duration_spin.blockSignals(True)
+        self.manual_duration_spin.setValue(duration)
+        self.navigation_duration_spin.setValue(duration)
+        self.manual_duration_spin.blockSignals(False)
+        self.navigation_duration_spin.blockSignals(False)
+        self.update_manual_duration_label()
+        self.update_nav_duration_label()
 
     def toggle_manual_feedback(self):
         self.manual_feedback_enabled = not self.manual_feedback_enabled

--- a/src/remote_pi_pkg/remote_pi_pkg/main.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/main.py
@@ -20,7 +20,7 @@ def main():
     rclpy.init()
 
     # Launch input nodes alongside the GUI
-    joy_proc = subprocess.Popen(['ros2', 'run', 'joy_linux', 'joy_linux_node'])
+    joy_proc = subprocess.Popen(['ros2', 'run', 'joy', 'joy_node'])
     mapper_proc = subprocess.Popen(['ros2', 'run', 'remote_pi_pkg', 'gamepad_mapper'])
     exit_code = 0
     try:

--- a/src/remote_pi_pkg/remote_pi_pkg/ros/gamepad_mapper.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/ros/gamepad_mapper.py
@@ -24,6 +24,8 @@ class GamepadMapper(Node):
         self.cruise_delay_pub = self.create_publisher(Float32, 'cruise_delay', 10)
         self.duration_factor_pub = self.create_publisher(
             Float32, 'canned_duration_factor', 10)
+        self.step_duration_pub = self.create_publisher(
+            Float32, 'step_duration', 10)
         self.subscription = self.create_subscription(Joy, 'joy', self.joy_callback, 10)
         self.last_buttons = []
         self.cruise_enabled = False
@@ -76,8 +78,8 @@ class GamepadMapper(Node):
             12: self._make_canned_handler(
                 self.canned_movements.canned_13_ACCEL),           # D-pad left
             13: self.toggle_cruise,                             # D-pad right
-            14: self.increase_duration_factor,                  # Misc button 1
-            15: self.decrease_cruise_delay,                     # Misc button 2
+            14: self.increase_step_duration,                    # Misc button 1
+            15: self.decrease_step_duration,                    # Misc button 2
             16: self.increase_cruise_delay,                     # Misc button 3
         }
 
@@ -145,12 +147,22 @@ class GamepadMapper(Node):
             Float32(data=self.canned_duration_factor)
         )
 
+    def increase_step_duration(self):
+        """Increase the duration multiplier for canned steps."""
+        self.step_duration += 0.1
+        self.step_duration_pub.publish(Float32(data=self.step_duration))
+
     def decrease_duration_factor(self):
         """Decrease canned movement duration scaling."""
         self.canned_duration_factor = max(0.2, self.canned_duration_factor - 0.2)
         self.duration_factor_pub.publish(
             Float32(data=self.canned_duration_factor)
         )
+
+    def decrease_step_duration(self):
+        """Decrease the duration multiplier for canned steps."""
+        self.step_duration = max(0.1, self.step_duration - 0.1)
+        self.step_duration_pub.publish(Float32(data=self.step_duration))
 
     def decrease_cruise_delay(self):
         """Reduce delay between cruise cycles."""


### PR DESCRIPTION
## Summary
- run the standard `joy_node` when launching the GUI
- publish step duration from `gamepad_mapper`
- notify the GUI when cruise/step parameters are changed via ROS
- sync GUI widgets when settings come from the gamepad

## Testing
- `colcon test --packages-select remote_pi_pkg` *(fails: `colcon` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859563363608332b4344263acef8a3e