### PR TITLE
Fix subprocess cleanup in main.py

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/main.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/main.py
@@ -42,8 +42,12 @@ def main():
         rclpy.shutdown()
         mapper_proc.terminate()
         joy_proc.terminate()
-        mapper_proc.wait()
-        joy_proc.wait()
+        for proc in (mapper_proc, joy_proc):
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
 
     sys.exit(exit_code)
 


### PR DESCRIPTION
## Summary
- ensure GUI subprocesses do not hang the shutdown

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for ament modules)*

------
https://chatgpt.com/codex/tasks/task_e_685963169ed48332bb1e7fd8cd7f426b