### PR TITLE
Fix GUI cruise and duration feedback

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
@@ -991,6 +991,16 @@ class AUVControlGUI(QWidget):
                 self.nav_pitch_pid_status_label.setStyleSheet(
                     "font-size: 18px; color: #FF4500;"
                 )
+
+        # --- Keep control widgets in sync with ROS state ---
+        if abs(self.manual_duration_spin.value() - self.ros_node.step_duration) > 1e-3:
+            self.on_step_duration_update(self.ros_node.step_duration)
+        if abs(self.navigation_duration_spin.value() - self.ros_node.step_duration) > 1e-3:
+            self.on_step_duration_update(self.ros_node.step_duration)
+        if abs(self.cruise_interval_spin.value() - self.ros_node.cruise_delay) > 1e-3:
+            self.on_cruise_delay_update(self.ros_node.cruise_delay)
+        if self.btn_cruise_toggle.isChecked() != self.ros_node.cruise_enabled:
+            self.on_cruise_enabled_update(self.ros_node.cruise_enabled)
             
 
 

--- a/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
@@ -993,12 +993,13 @@ class AUVControlGUI(QWidget):
                 )
 
         # --- Keep control widgets in sync with ROS state ---
-        if abs(self.manual_duration_spin.value() - self.ros_node.step_duration) > 1e-3:
+        if abs(self.manual_duration_spin.value() - self.ros_node.step_duration) > 1e-3 or \
+           abs(self.navigation_duration_spin.value() - self.ros_node.step_duration) > 1e-3:
             self.on_step_duration_update(self.ros_node.step_duration)
-        if abs(self.navigation_duration_spin.value() - self.ros_node.step_duration) > 1e-3:
-            self.on_step_duration_update(self.ros_node.step_duration)
+
         if abs(self.cruise_interval_spin.value() - self.ros_node.cruise_delay) > 1e-3:
             self.on_cruise_delay_update(self.ros_node.cruise_delay)
+
         if self.btn_cruise_toggle.isChecked() != self.ros_node.cruise_enabled:
             self.on_cruise_enabled_update(self.ros_node.cruise_enabled)
             


### PR DESCRIPTION
## Summary
- keep duration and cruise widgets synced with ROS state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: ament_flake8)*

------
https://chatgpt.com/codex/tasks/task_e_68596a7d9e0c8332ad48a472c34ed5c1