### PR TITLE
Fix asset paths

### DIFF
--- a/install_shortcut.sh
+++ b/install_shortcut.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Absolute paths
-WORKSPACE_DIR="$HOME/RemotePiRos2"
+# Determine workspace location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="${REMOTE_PI_WS:-$SCRIPT_DIR}"
 LAUNCH_SCRIPT="$WORKSPACE_DIR/launch_gui.sh"
 ICON_PATH="$WORKSPACE_DIR/assets/icon.png"
 DESKTOP_FILE="$HOME/.local/share/applications/auv-control.desktop"

--- a/launch_gui.sh
+++ b/launch_gui.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 export QT_QPA_PLATFORM=xcb
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="${REMOTE_PI_WS:-$SCRIPT_DIR}"
+
 source /opt/ros/jazzy/setup.bash
-source /home/b/RemotePiRos2/install/setup.bash
+source "$WORKSPACE_DIR/install/setup.bash"
 ros2 run remote_pi_pkg auv_control

--- a/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
@@ -16,6 +16,8 @@ from lifecycle_msgs.msg import Transition
 from PyQt5.QtGui import QTextOption
 import time
 import os
+from importlib import resources
+from pathlib import Path
 
 class AUVControlGUI(QWidget):
     def __init__(self, ros_node):
@@ -33,7 +35,15 @@ class AUVControlGUI(QWidget):
 
         # === GUI Styling and Background ===
         script_dir = os.path.dirname(os.path.realpath(__file__))
-        bg_path = "/home/b/RemotePiRos2/assets/background.png"
+        pkg_path = Path(resources.files(__package__))
+        bg_path = None
+        for parent in [pkg_path] + list(pkg_path.parents):
+            candidate = parent / 'assets' / 'background.png'
+            if candidate.exists():
+                bg_path = str(candidate)
+                break
+        if bg_path is None:
+            bg_path = str(pkg_path / 'background.png')
         self.setStyleSheet(f"""
             /* === TRANSPARENCY FIX FOR QTextEdit === */
             QTextEdit, QTextEdit QAbstractScrollArea, QTextEdit::viewport {{


### PR DESCRIPTION
## Summary
- dynamically resolve background image in `auv_control_gui.py`
- make `launch_gui.sh` source the workspace using its own path or `$REMOTE_PI_WS`
- make `install_shortcut.sh` create scripts relative to the workspace

## Testing
- `colcon test --packages-select remote_pi_pkg` *(fails: colcon not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4a9ce42c8332b14f3c444ce50127