### PR TITLE
Fix step duration callback

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
@@ -142,6 +142,7 @@ class AUVControlGUI(QWidget):
         )
         self.ros_node.cruise_enabled_update_callback = self.cruiseEnabledChanged.emit
         self.ros_node.cruise_delay_update_callback = self.cruiseDelayChanged.emit
+        self.ros_node.step_duration_update_callback = self.stepDurationChanged.emit
 
 
 


### PR DESCRIPTION
## Summary
- connect step duration update callback to AUVControlGUI

## Testing
- `colcon test --packages-select remote_pi_pkg` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a87cd29108332b778dbc2176a8467