### PR TITLE
Adjust navigation tab layout and cleanup

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/main.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/main.py
@@ -34,7 +34,7 @@ def main():
         # Start Qt GUI
         app = QApplication(sys.argv)
         signal.signal(signal.SIGINT, lambda *args: app.quit())
-        gui = AUVControlGUI(ros_node)
+        gui = AUVControlGUI(ros_node, joy_proc=joy_proc, mapper_proc=mapper_proc)
         gui.show()
         exit_code = app.exec_()
     finally:


### PR DESCRIPTION
## Summary
- ensure helper ROS nodes terminate when GUI closes
- open GUI on the Navigation tab and shrink its joystick
- tweak navigation status fonts and servo driver layout
- pass subprocess handles into the GUI so it can terminate them

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ament_copyright')*

------
https://chatgpt.com/codex/tasks/task_e_685a9e6c2fb0833292353c6ab3562542