### PR TITLE
Add step duration sync

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
@@ -334,6 +334,7 @@ class AUVControlGUI(QWidget):
         self.btn_step_duration_decrease.clicked.connect(self.manual_duration_spin.stepDown)
         self.btn_step_duration_increase.clicked.connect(self.manual_duration_spin.stepUp)
         self.manual_duration_spin.valueChanged.connect(self.update_manual_duration_label)
+        self.manual_duration_spin.valueChanged.connect(self.step_duration_value_changed)
 
         duration_row.addWidget(self.btn_step_duration_decrease)
         duration_row.addWidget(self.manual_duration_label)
@@ -445,6 +446,7 @@ class AUVControlGUI(QWidget):
         self.btn_nav_duration_decrease.clicked.connect(self.navigation_duration_spin.stepDown)
         self.btn_nav_duration_increase.clicked.connect(self.navigation_duration_spin.stepUp)
         self.navigation_duration_spin.valueChanged.connect(self.update_nav_duration_label)
+        self.navigation_duration_spin.valueChanged.connect(self.step_duration_value_changed)
 
         nav_duration_row.addWidget(self.btn_nav_duration_decrease)
         nav_duration_row.addWidget(self.navigation_duration_label)
@@ -743,6 +745,10 @@ class AUVControlGUI(QWidget):
             self.update_nav_duration_label()
 
         self.last_step_duration = duration
+
+    def step_duration_value_changed(self, value: float):
+        """Propagate step duration changes to the ROS node."""
+        self.ros_node.set_step_duration(float(value))
 
     def toggle_manual_feedback(self):
         self.manual_feedback_enabled = not self.manual_feedback_enabled

--- a/src/remote_pi_pkg/remote_pi_pkg/ros/interface.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/ros/interface.py
@@ -67,6 +67,7 @@ class ROSInterface(Node):
         self.tail_pid_pub = self.create_publisher(Bool, 'tail_pid_active', 10)
         self.create_subscription(Bool, 'tail_pid_active',
                                  self.tail_pid_status_callback, 10)
+        self.step_duration_pub = self.create_publisher(Float32, 'step_duration', 10)
 
         
         # Lifecycle service client
@@ -504,6 +505,19 @@ class ROSInterface(Node):
             except Exception as e:
                 self.get_logger().error(
                     f"Duration factor GUI callback failed: {e}")
+
+    def set_step_duration(self, duration: float):
+        """Update and publish the canned step duration."""
+        self.step_duration = float(duration)
+        msg = Float32()
+        msg.data = self.step_duration
+        self.step_duration_pub.publish(msg)
+        if hasattr(self, 'step_duration_update_callback'):
+            try:
+                self.step_duration_update_callback(self.step_duration)
+            except Exception as e:
+                self.get_logger().error(
+                    f"Step duration GUI callback failed: {e}")
 
     def step_duration_callback(self, msg: Float32):
         """Handle updates to the step duration from the gamepad."""


### PR DESCRIPTION
## Summary
- create a `/step_duration` publisher in `ROSInterface`
- add `set_step_duration` helper to publish and update
- sync GUI spin boxes with ROS step duration updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for ament packages)*

------
https://chatgpt.com/codex/tasks/task_e_685cb244e2b88332908fc3ac1bf54e78