### PR TITLE
Improve subprocess cleanup reliability

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/main.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/main.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
 import signal
+import logging
+import atexit
 
 # === Enable OpenGL acceleration ===
 os.environ['QT_QPA_PLATFORM'] = 'xcb'  # Try 'eglfs' if 'xcb' gives issues
@@ -13,6 +15,39 @@ import rclpy
 from PyQt5.QtWidgets import QApplication
 from remote_pi_pkg.ros.interface import ROSInterface
 from remote_pi_pkg.auv_control_gui import AUVControlGUI
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def cleanup_processes(processes):
+    """Terminate external helper processes."""
+    for name, proc in processes:
+        if proc.poll() is None:
+            try:
+                os.killpg(proc.pid, signal.SIGINT)
+            except ProcessLookupError:
+                logger.warning(
+                    "Process %s already terminated before SIGINT", name
+                )
+            except Exception:  # pragma: no cover - unexpected errors
+                logger.exception("Failed to send SIGINT to %s", name)
+    for name, proc in processes:
+        if proc.poll() is None:
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    "Process %s did not exit after SIGINT; killing", name
+                )
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    logger.warning(
+                        "Process %s disappeared before SIGKILL", name
+                    )
+                except Exception:  # pragma: no cover - unexpected errors
+                    logger.exception("Failed to send SIGKILL to %s", name)
+                proc.wait()
 
 def ros_spin(node):
     rclpy.spin(node)
@@ -27,8 +62,14 @@ def main():
         ['ros2', 'run', 'joy', 'joy_node'], start_new_session=True
     )
     mapper_proc = subprocess.Popen(
-        ['ros2', 'run', 'remote_pi_pkg', 'gamepad_mapper'], start_new_session=True
+        ['ros2', 'run', 'remote_pi_pkg', 'gamepad_mapper'],
+        start_new_session=True,
     )
+    procs = [
+        ('joy_node', joy_proc),
+        ('gamepad_mapper', mapper_proc),
+    ]
+    atexit.register(cleanup_processes, procs)
     exit_code = 0
     ros_node = None
     try:
@@ -49,22 +90,7 @@ def main():
             ros_node.destroy_node()
         rclpy.shutdown()
 
-        for proc in (mapper_proc, joy_proc):
-            if proc.poll() is None:
-                try:
-                    os.killpg(proc.pid, signal.SIGINT)
-                except ProcessLookupError:
-                    pass
-        for proc in (mapper_proc, joy_proc):
-            if proc.poll() is None:
-                try:
-                    proc.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    try:
-                        os.killpg(proc.pid, signal.SIGKILL)
-                    except ProcessLookupError:
-                        pass
-                    proc.wait()
+        cleanup_processes(procs)
 
     sys.exit(exit_code)
 


### PR DESCRIPTION
## Summary
- register cleanup routines with `atexit`
- refactor cleanup loops into a reusable helper in `main.py`
- add logging for failures during process termination
- log and register cleanup for GUI helper nodes

## Testing
- `colcon test --packages-select remote_pi_pkg` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cba43b6488332a4e45514a64aa525