### PR TITLE
Fix canned movement button creation

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
@@ -339,6 +339,14 @@ class AUVControlGUI(QWidget):
         # Left side: canned movement buttons
         nav_left_layout = QVBoxLayout()
         self.navigation_step_buttons = []
+
+        canned_re = re.compile(r"^canned_(\d+)(?:_(.*))?$")
+        method_names = [
+            name for name in dir(self.ros_node.canned_movements)
+            if canned_re.match(name)
+        ]
+        method_names.sort(key=lambda n: int(canned_re.match(n).group(1)))
+
         for name in method_names:
             match = canned_re.match(name)
             suffix = match.group(2)


### PR DESCRIPTION
## Summary
- fix undefined `method_names` error by querying canned movement methods

## Testing
- `colcon test --packages-select remote_pi_pkg` *(fails: colcon not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d03622e748332bba9e23a3eb02c8c