### PR TITLE
Enable dynamic step duration during cruise

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/auv_control_gui.py
@@ -675,7 +675,9 @@ class AUVControlGUI(QWidget):
         def handler():
             dur = self.navigation_duration_spin.value()
             method(duration_scale=dur)
-            self.ros_node.last_canned_callback = lambda: method(duration_scale=dur)
+            self.ros_node.last_canned_callback = (
+                lambda: method(duration_scale=self.navigation_duration_spin.value())
+            )
         return handler
 
     def send_canned_and_remember(self):

--- a/src/remote_pi_pkg/remote_pi_pkg/ros/gamepad_mapper.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/ros/gamepad_mapper.py
@@ -119,9 +119,10 @@ class GamepadMapper(Node):
 
     def _make_canned_handler(self, method):
         def handler():
-            dur = self.step_duration
-            method(duration_scale=dur)
-            self.last_canned_callback = lambda: method(duration_scale=dur)
+            method(duration_scale=self.step_duration)
+            self.last_canned_callback = (
+                lambda: method(duration_scale=self.step_duration)
+            )
         return handler
 
     def joy_callback(self, msg: Joy):


### PR DESCRIPTION
## Summary
- ensure cruise repetitions use the current step duration
- update GUI handler to use live spin box value

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: ament_flake8, ament_pep257)*

------
https://chatgpt.com/codex/tasks/task_e_685d06fa4c30833285b379ceff71f24b