### PR TITLE
Catch joystick action errors in gamepad mapper

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/ros/gamepad_mapper.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/ros/gamepad_mapper.py
@@ -162,7 +162,12 @@ class GamepadMapper(Node):
 
         for idx, action in self.button_actions.items():
             if pressed(idx):
-                action()
+                try:
+                    action()
+                except Exception:
+                    self.get_logger().exception(
+                        f"Error executing action for button {idx}"
+                    )
 
         self.last_buttons = list(msg.buttons)
 
@@ -177,11 +182,21 @@ class GamepadMapper(Node):
             if prev <= self.axis_threshold and val > self.axis_threshold:
                 handler = actions.get('positive')
                 if handler:
-                    handler()
+                    try:
+                        handler()
+                    except Exception:
+                        self.get_logger().exception(
+                            f"Error executing positive axis action for axis {idx}"
+                        )
             elif prev >= -self.axis_threshold and val < -self.axis_threshold:
                 handler = actions.get('negative')
                 if handler:
-                    handler()
+                    try:
+                        handler()
+                    except Exception:
+                        self.get_logger().exception(
+                            f"Error executing negative axis action for axis {idx}"
+                        )
             if idx < len(self.last_axes):
                 self.last_axes[idx] = val
 


### PR DESCRIPTION
## Summary
- log and continue when joystick button handler raises
- guard axis handlers against exceptions to avoid node crashes

## Testing
- `python -m py_compile src/remote_pi_pkg/remote_pi_pkg/ros/gamepad_mapper.py`
- `pytest` *(fails: No module named 'rclpy'; No module named 'ament_copyright'; No module named 'ament_flake8'; No module named 'ament_pep257')*


------
https://chatgpt.com/codex/tasks/task_e_689c3fc4616c83329c0469b87e817955