### PR TITLE
Log unmapped joystick button presses

### DIFF
--- a/src/remote_pi_pkg/remote_pi_pkg/ros/gamepad_mapper.py
+++ b/src/remote_pi_pkg/remote_pi_pkg/ros/gamepad_mapper.py
@@ -160,13 +160,19 @@ class GamepadMapper(Node):
             self.last_press_times[index] = time.time()
             return True
 
-        for idx, action in self.button_actions.items():
+        for idx in range(len(msg.buttons)):
             if pressed(idx):
-                try:
-                    action()
-                except Exception:
-                    self.get_logger().exception(
-                        f"Error executing action for button {idx}"
+                action = self.button_actions.get(idx)
+                if action:
+                    try:
+                        action()
+                    except Exception:
+                        self.get_logger().exception(
+                            f"Error executing action for button {idx}"
+                        )
+                else:
+                    self.get_logger().debug(
+                        f"Unmapped button {idx} pressed"
                     )
 
         self.last_buttons = list(msg.buttons)


### PR DESCRIPTION
## Summary
- Extend `joy_callback` to inspect every button index
- Log a debug message when an unmapped button is pressed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rclpy')*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c410ba9148332bc7dad8b748845ea